### PR TITLE
minor change to fit2anarc.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,147 @@
+__pycache__/
+*.py[cod]
+*$py.class
+
+#apple
+.DS_Store
+
+# text, and data files
+*.txt
+*.dat
+
+_site
+Gemfile.lock
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# manim
+media/
+Tex/
+texts/
+*.aux
+*.dvi
+*.svg
+*.mp4

--- a/src/modpilgrim/fit2anarc.py
+++ b/src/modpilgrim/fit2anarc.py
@@ -47,7 +47,8 @@ from   common.physcons import KB
 from   common.fncs     import exp128
 from   scipy.optimize  import curve_fit
 #-------------------------------------------------------#
-np.warnings.filterwarnings('ignore')
+import warnings
+warnings.filterwarnings('ignore')
 #=======================================================#
 
 TR_DEFAULT = 300.0


### PR DESCRIPTION
Here is summary of change.

1. `numpy.warnings` were removed from numpy, and people started using built-in `warnings` package over time. I have just replaced `numpy.warnings` with `warnings` in line 50 on the fit2anarc.py
2. Added .gitignore file suitable for python